### PR TITLE
Remove extra addr funcs + add array method to QRC721

### DIFF
--- a/QRC20X.sol
+++ b/QRC20X.sol
@@ -71,11 +71,11 @@ contract QRC20 {
      * All two of these values are immutable: they can only be set once during
      * construction.
      */
-    constructor() {
-        _name = "Quai Cross-Chain Token";
-        _symbol = "QXC";
+    constructor(string memory name_, string memory symbol_, uint256 initialSupply_) {
+        _name = name_;
+        _symbol = symbol_;
         _deployer = msg.sender;
-        uint256 initialSupply = 1000E18; // 1000 tokens
+        uint256 initialSupply = initialSupply_;
         _mint(_deployer, initialSupply);
         Ranges[0] = Range(0, 29);    // zone 0-0 // cyprus1                        
         Ranges[1] = Range(30, 58); // zone 0-1 // cyprus2
@@ -482,23 +482,6 @@ contract QRC20 {
         address to,
         uint256 amount
     ) internal  {}
-
-    /**
-    * This function allows the deployer to add an external address for the token contract on a different chain.
-    * Note that the deployer can only add one address per chain and this address cannot be changed afterwards.
-    * Be very careful when adding an address here.
-    */
-    function AddApprovedAddress(uint8 chain, address addr) public {
-        bool isInternal;
-        assembly {
-            isInternal := isaddrinternal(addr)
-        }
-        require(!isInternal, "Address is not external");
-        require(msg.sender == _deployer, "Sender is not deployer");
-        require(chain < 9, "Max 9 zones");
-        require(ApprovedAddresses[chain] == address(0), "The approved address for this zone already exists");
-        ApprovedAddresses[chain] = addr;
-    }
 
     /**
     * This function allows the deployer to add external addresses for the token contract on different chains.

--- a/QRC721X.sol
+++ b/QRC721X.sol
@@ -139,9 +139,9 @@ contract QRC721 is IERC721Errors {
     /**
      * @dev Initializes the contract by setting a `name` and a `symbol` to the token collection.
      */
-    constructor() {
-        _name = "Quai Cross-Chain NFT";
-        _symbol = "QXC";
+    constructor(string memory name_, string memory symbol_) {
+        _name = name_;
+        _symbol = symbol_;
         _deployer = msg.sender;
         _mint(_deployer, 0);
         Ranges[0] = Range(0, 29);    // zone 0-0 // cyprus1                        
@@ -626,21 +626,21 @@ contract QRC721 is IERC721Errors {
         }
     }
 
-     /**
-    * This function allows the deployer to add an external address for the token contract on a different chain.
+    /**
+    * This function allows the deployer to add external addresses for the token contract on different chains.
     * Note that the deployer can only add one address per chain and this address cannot be changed afterwards.
-    * Be very careful when adding an address here.
+    * In comparison to AddApprovedAddress, this function allows the address(es) to be internal so that the same
+    * approved list can be used for every instance of the contract on each chain.
+    * Be very careful when adding addresses here.
     */
-    function AddApprovedAddress(uint8 chain, address addr) public {
-        bool isInternal;
-        assembly {
-            isInternal := isaddrinternal(addr)
-        }
-        require(!isInternal, "Address is not external");
+    function AddApprovedAddresses(uint8[] calldata chain, address[] calldata addr) external {
         require(msg.sender == _deployer, "Sender is not deployer");
-        require(chain < 9, "Max 9 zones");
-        require(ApprovedAddresses[chain] == address(0), "The approved address for this zone already exists");
-        ApprovedAddresses[chain] = addr;
+        require(chain.length == addr.length, "chain and address arrays must be the same length");
+        for(uint8 i = 0; i < chain.length; i++) {
+            require(chain[i] < 9, "Max 9 zones");
+            require(ApprovedAddresses[chain[i]] == address(0), "The approved address for this zone already exists");
+            ApprovedAddresses[chain[i]] = addr[i];
+        }
     }
 
     // This function uses the stored prefix list to determine an address's location based on its first byte.


### PR DESCRIPTION
- Remove hardcoded constructor args in both contracts
- Remove `AddApprovedAddress` function as it is redundant
- Added `AddApprovedAddresses` function to QRC721