### PR TITLE
Change simple return functions to pure

### DIFF
--- a/QRC20X.sol
+++ b/QRC20X.sol
@@ -116,7 +116,7 @@ contract QRC20 {
      * no way affects any of the arithmetic of the contract, including
      * {IERC20-balanceOf} and {IERC20-transfer}.
      */
-    function decimals() public view  returns (uint8) {
+    function decimals() public pure  returns (uint8) {
         return 18;
     }
 

--- a/QRC721X.sol
+++ b/QRC721X.sol
@@ -205,7 +205,7 @@ contract QRC721 is IERC721Errors {
      * token will be the concatenation of the `baseURI` and the `tokenId`. Empty
      * by default, can be overridden in child contracts.
      */
-    function _baseURI() internal view  returns (string memory) {
+    function _baseURI() internal pure  returns (string memory) {
         return "https://qu.ai/nft/";
     }
 


### PR DESCRIPTION
Both of these functions are throwing compiler warnings when compiled, changed them to `pure` for simplicity and to fix the compiler warnings.